### PR TITLE
libring build command now uses subprocess module.

### DIFF
--- a/py-OTRS/src/crypto_otrs/__init__.py
+++ b/py-OTRS/src/crypto_otrs/__init__.py
@@ -4,6 +4,7 @@
 __version__ = "1.0.4"
 
 import os
+import subprocess
 script_dir = os.path.abspath(os.path.dirname(__file__))
 lib_path = os.path.join(script_dir, "libring.so")
 sha_path = os.path.join(script_dir, "sha2.c")
@@ -11,4 +12,4 @@ ring_path = os.path.join(script_dir, "ring.c")
 
 if os.path.exists(lib_path) == False:
     print("libring not found, compiling...")
-    os.system("clang -fPIC -shared -g -lm -lssl -lcrypto " + sha_path + " " + ring_path + " -o "+lib_path)
+    subprocess.run(["clang", "-fPIC", "-shared", "-g", "-lm", "-lssl", "-lcrypto", sha_path, ring_path, "-o", lib_path])


### PR DESCRIPTION
Using the subprocess module allows it to handle spaces in paths properly.